### PR TITLE
Shift+ENTER indent spacing fix

### DIFF
--- a/main.js
+++ b/main.js
@@ -16,9 +16,10 @@ define(function (require, exports, module) {
     for (i = 0; i < inLine.length; i += 1) {
       if (inLine[i].trim() === '') {
         spacesString += inLine[i];
+      } else {
+        return spacesString;
       }
     }
-    return spacesString;
   }
   function fileTypes(fileLang) {
     switch (fileLang) {


### PR DESCRIPTION
For shift+ENTER command:

Currently, the new line’s indent seems to include additional spaces,
when the current line has any spaces occurring after the indent.

This proposed fix stops counting indent spaces once the first character
is reached.
